### PR TITLE
Fix #196: App crashes / exits / quits after closing an openFileChoose…

### DIFF
--- a/src/modules/ui/gtk/gtk_user_window.cpp
+++ b/src/modules/ui/gtk/gtk_user_window.cpp
@@ -1337,8 +1337,11 @@ namespace ti
             g_free(f);
         }
     
-        openFilesDirectory =
+        gchar* g_openFilesDirectory =
              gtk_file_chooser_get_current_folder(GTK_FILE_CHOOSER(chooser));
+        if (g_openFilesDirectory)
+            openFilesDirectory = g_openFilesDirectory;
+
         gtk_widget_destroy(chooser);
 
         try


### PR DESCRIPTION
…rDialog()